### PR TITLE
Style: 여행 포럼의 인기 카드 아이템 컴포넌트 생성:

### DIFF
--- a/src/components/cardItems/HotBedge.tsx
+++ b/src/components/cardItems/HotBedge.tsx
@@ -1,0 +1,9 @@
+const HotBedge = () => {
+	return (
+		<div className="absolute right-0 text-xs border rounded-lg px-0.5 text-cent p-auto er top-3 text-POINT_COLOR border-POINT_COLOR">
+			인기글
+		</div>
+	);
+};
+
+export default HotBedge;

--- a/src/components/cardItems/HotItem.tsx
+++ b/src/components/cardItems/HotItem.tsx
@@ -1,0 +1,22 @@
+import Temp from "@/assets/img/temp.png";
+import HotBedge from "./HotBedge";
+
+const HotItem = () => {
+	return (
+		<div className="relative flex flex-col p-3 border w-72 h-fit border-LIGHT_GRAY_COLOR text-BASIC_BLACK bg-BASIC_WHITE">
+			<div className="">
+				<img src={Temp} alt="temp Image" className="object-cover h-48 w-62" />
+			</div>
+			<div className="relative flex-1 text-xl font-bold">
+				<p className="z-50 my-3"> 최고의 경주 여행!</p>
+				<HotBedge />
+				<span className="absolute left-0 inline p-2 bottom-1.5 realtive bg-SPECIAL_COLOR z-10"></span>
+			</div>
+			<div className="text-sm font-light text-right text-BASIC_BLACK">
+				작성자
+			</div>
+		</div>
+	);
+};
+
+export default HotItem;


### PR DESCRIPTION
# 개요
여행 포럼의 인기 카드 아이템 컴포넌트 생성 

# 작업 사항
- 여행 포럼의 상단에 게시 될 인기 게시글 카드 아이템 컴포넌트 생성 > HotItem.tsx
- 그 외 카드 아이템 컴포넌트 > CardItem.tsx (생성 중)

# 특이 사항
- 카드 아이템의 TItle 부분의 하이라이터 처리 적용 안됨 
- 현재 3개 아이템만 정렬 ( 추 후  카드 슬라이드 처리 고려 중 ) 

# 미리 보기
![스크린샷 2023-12-01 오후 10 41 20](https://github.com/TRIP-Side-Project/frontend/assets/110151638/86270355-addb-4497-9182-d4829d8523c4)

