### PR TITLE
Style: 여행 포럼 페이지 세부 UI 설정

### DIFF
--- a/src/components/Pagenation.tsx
+++ b/src/components/Pagenation.tsx
@@ -3,7 +3,7 @@ import ArrowLeft from "@/assets/svg/ArrowLeft";
 import ArrowRight from "@/assets/svg/ArrowRight";
 
 const Pagenation = () => {
-	const [activeBtn, setActiveBtn] = useState<number | null>(null);
+	const [activeBtn, setActiveBtn] = useState<number>(1);
 	// const activeBtn = isClick ? "font-bold text-BTN_HOVER_COLOR" : "";
 	// const numBtn = `mx-2 ${activeBtn}`;
 

--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,9 +1,10 @@
 export interface btnAttributes {
 	width: string;
-	height: string;
+	// height: string;
 	text: string;
 	bgColor?: string;
 	border?: string;
+	position?: string;
 	type: "circle" | "square";
 }
 
@@ -12,13 +13,13 @@ interface btnTypes {
 }
 
 const Button = ({ btnInfo }: btnTypes) => {
-	const { width, height, bgColor, border, text, type } = btnInfo;
+	const { width, bgColor, border, position, text, type } = btnInfo;
 	const basicStyle = type === "circle" ? "blue_circleBtn" : `blue_squareBtn`;
 	const bg = bgColor ? `bg-${bgColor}` : "";
 	const borderStyle = border ? `border border-${border}` : "";
-	console.log(width, height, bg, borderStyle);
-	const btnStyle = `${basicStyle} `;
-
+	const float = position ? `float-${position}` : "";
+	const btnStyle = `${basicStyle} w-[${width}] ${float} ${bg} ${borderStyle} `;
+	console.log(btnStyle);
 	//circle | square
 
 	return (

--- a/src/components/cardItems/CardItem.tsx
+++ b/src/components/cardItems/CardItem.tsx
@@ -1,0 +1,18 @@
+import Temp from "@/assets/img/temp.png";
+
+const CardItem = () => {
+	return (
+		<div className="w-[348px] h-[360px] bg-BASIC_WHITE text-BASIC_BLACK rounded-lg flex flex-col">
+			<div className="m-3 rounded-lg">
+				<img src={Temp} alt="tempImage" />
+			</div>
+			<div className="text-xl font-medium">경주 여행 첨성대</div>
+			<div className="text-sm font-light text-LIGHT_GRAY_COLOR">
+				@아리아리랑 투어
+			</div>
+			<div className="font-medium text-right">₩ 1,000,000원</div>
+		</div>
+	);
+};
+
+export default CardItem;

--- a/src/index.css
+++ b/src/index.css
@@ -4,9 +4,9 @@
 
 @layer components {
     .blue_squareBtn {
-        @apply py-2 px-5 text-center bg-MAIN_COLOR text-BASIC_WHITE hover:bg-BTN_HOVER_COLOR rounded-lg font-medium;
+        @apply py-2 px-5 my-3 text-center bg-MAIN_COLOR text-BASIC_WHITE hover:bg-BTN_HOVER_COLOR rounded-lg font-medium;
     }
     .blue_circleBtn {
-        @apply py-2 px-5 bg-MAIN_COLOR text-BASIC_WHITE hover:bg-BTN_HOVER_COLOR rounded-3xl font-medium;
+        @apply py-2 px-5 my-3 bg-MAIN_COLOR text-BASIC_WHITE hover:bg-BTN_HOVER_COLOR rounded-3xl font-medium;
     }
 }

--- a/src/pages/Forum.tsx
+++ b/src/pages/Forum.tsx
@@ -1,9 +1,18 @@
 import Pagenation from "@/components/Pagenation";
+import Button, { btnAttributes } from "@/components/button/Button";
 import HotItem from "@/components/cardItems/HotItem";
 import ForumItem from "@/components/forumItems/ForumItem";
 import Search from "@/components/search/Search";
 
 const Forum = () => {
+	const btnInfo: btnAttributes = {
+		width: "172px",
+		// height: "50px",
+		position: "right",
+		text: "새 글 등록하기",
+		type: "square",
+	};
+
 	return (
 		<div className="flex flex-col text-BASIC_BLACK max-w-[1200px]">
 			{/* 상단 인기 여행 아이템 섹션 */}
@@ -40,6 +49,7 @@ const Forum = () => {
 						<ForumItem key={index} />
 					))}
 				</div>
+				<Button btnInfo={btnInfo} />
 				<Pagenation />
 			</div>
 		</div>


### PR DESCRIPTION
# 개요
여행 포럼 페이지 세부 UI 설정

# 작업 사항
- 버튼 재사용 컴포넌트의 margin y 축 설정 및 좌 우 정렬 혹은 중앙 정렬 설정할 수 있게 코드 수정 
   * 사용할 때 poaition:  "right" | "left" | "center" 설정 가능 (tailwindCSS의 float 기능 적용하였습니다. 

# 미리 보기 
<img width="656" alt="스크린샷 2023-12-03 오후 9 51 48" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/b55a644a-6408-43af-947d-b35a2eea51b2">
