### PR TITLE
Style: 여행 포럼 디테일 페이지 댓글 컴포넌트 생성

### DIFF
--- a/src/assets/svg/ArrowComment.tsx
+++ b/src/assets/svg/ArrowComment.tsx
@@ -1,0 +1,27 @@
+import { SVG } from "@/types/svg";
+
+const ArrowComment = ({ fillColor, width, height }: SVG) => {
+	fillColor = fillColor ? `${fillColor}` : "#000000";
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 24 24"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<g id="Arrow / Arrow_Sub_Down_Right">
+				<path
+					id="Vector"
+					d="M13 11L18 16M18 16L13 21M18 16H10.1969C9.07899 16 8.5192 16 8.0918 15.7822C7.71547 15.5905 7.40973 15.2839 7.21799 14.9076C7 14.4798 7 13.9201 7 12.8V3"
+					stroke={fillColor}
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				/>
+			</g>
+		</svg>
+	);
+};
+
+export default ArrowComment;

--- a/src/assets/svg/ArrowDown.tsx
+++ b/src/assets/svg/ArrowDown.tsx
@@ -1,0 +1,19 @@
+import { SVG } from "@/types/svg";
+
+const ArrowDown = ({ width, height }: SVG) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 48 48"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="M0 0h48v48H0z" fill="none" />
+			<g id="Shopicon">
+				<polygon points="24,29.172 9.414,14.586 6.586,17.414 24,34.828 41.414,17.414 38.586,14.586 	" />
+			</g>
+		</svg>
+	);
+};
+
+export default ArrowDown;

--- a/src/assets/svg/ArrowUp.tsx
+++ b/src/assets/svg/ArrowUp.tsx
@@ -1,0 +1,19 @@
+import { SVG } from "@/types/svg";
+
+const ArrowUp = ({ width, height }: SVG) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="0 0 48 48"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path d="M0 0h48v48H0z" fill="none" />
+			<g id="Shopicon">
+				<polygon points="6.586,30.586 9.414,33.414 24,18.828 38.586,33.414 41.414,30.586 24,13.172 	" />
+			</g>
+		</svg>
+	);
+};
+
+export default ArrowUp;

--- a/src/common/button/AmendBtn.tsx
+++ b/src/common/button/AmendBtn.tsx
@@ -1,0 +1,5 @@
+const AmendBtn = () => {
+	return <div className="mx-2 text-sm text-DARK_GRAY_COLOR">수정</div>;
+};
+
+export default AmendBtn;

--- a/src/common/button/Button.tsx
+++ b/src/common/button/Button.tsx
@@ -15,14 +15,14 @@ interface btnTypes {
 
 const Button = ({ btnInfo }: btnTypes) => {
 	const { width, bgColor, textColor, border, position, text, type } = btnInfo;
-	console.log(btnInfo);
+	//console.log(btnInfo);
 	const basicStyle = type === "circle" ? "blue_circleBtn" : `blue_squareBtn`;
 	const bg = bgColor ? `bg-${bgColor}` : "";
 	const borderStyle = border ? `border border-${border}` : "";
 	const float = position ? `float-${position}` : "";
 	const tColor = textColor ? `text-${textColor}` : "";
 	const btnStyle = `${basicStyle} w-[${width}] ${float} ${bg} ${borderStyle} ${tColor} `;
-	console.log(btnStyle);
+	//console.log(btnStyle);
 	//circle | square
 
 	return (

--- a/src/common/button/DeleteBtn.tsx
+++ b/src/common/button/DeleteBtn.tsx
@@ -1,0 +1,5 @@
+const DeleteBtn = () => {
+	return <div className="mx-2 text-sm text-DARK_GRAY_COLOR">삭제</div>;
+};
+
+export default DeleteBtn;

--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+
+import Temp from "@/assets/img/temp.png";
+import DeleteBtn from "@/common/button/DeleteBtn";
+import AmendBtn from "@/common/button/AmendBtn";
+import HideComment from "@/components/comment/HideComment";
+import EditComment from "./EditComment";
+import ArrowComment from "@/assets/svg/ArrowComment";
+
+const Comment = () => {
+	const [isHide, setIsHide] = useState(false);
+	const [is2CHide, setIs2CHide] = useState(false);
+	// const isWrite2C = is2CHide ? "댓글 취소" : "댓글 쓰기";
+
+	const handleHideComment = () => {
+		setIsHide(!isHide);
+	};
+
+	const handle2CHide = () => {
+		setIs2CHide(!is2CHide);
+	};
+
+	return (
+		<div className="py-5 ">
+			{/* 댓글 등록 파트  */}
+			<EditComment />
+			{/* 댓글 내용 파트 */}
+			<div className="py-3 mt-10 border-y-2 border-LIGHT_GRAY_COLOR">
+				<div className="flex flex-row justify-between px-2 py-2 ">
+					<img src={Temp} alt="userImage" className="rounded-full w-14 h-14" />
+					<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+						<div className="text-lg font-semibold">리랑이</div>
+						<div className="">본문 내용 섹션 입니다. 라랄랄라랄랄랄랄ㄹ</div>
+					</div>
+					<div className="flex flex-row ">
+						<div className="mx-3 text-sm text-DARK_GRAY_COLOR">2023.11.24</div>
+						<AmendBtn />
+						<DeleteBtn />
+					</div>
+				</div>
+
+				<div className="flex flex-row my-3">
+					{isHide ? (
+						<HideComment type={"hide"} onClick={handleHideComment} />
+					) : (
+						<HideComment type={"show"} onClick={handleHideComment} />
+					)}
+					<button
+						className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
+						onClick={handle2CHide}
+					>
+						{is2CHide ? "댓글 취소" : "댓글 쓰기"}
+					</button>
+				</div>
+				{/* 대댓글 */}
+				{isHide ? (
+					<div className="ml-10 bg-LINE_POINT_COLOR ">
+						{Array.from(Array(2), (_, idx) => (
+							<div
+								key={idx}
+								className="flex flex-row justify-between px-2 py-2 my-1 border-b border-b-LIGHT_GRAY_COLOR"
+							>
+								<ArrowComment width={"25px"} height={"25px"} />
+								<img
+									src={Temp}
+									alt="userImage"
+									className="ml-3 rounded-full w-14 h-14"
+								/>
+								<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+									<div className="text-lg font-semibold">리랑이</div>
+									<div className="">
+										본문 내용 섹션 입니다. 라랄랄라랄랄랄랄ㄹ
+									</div>
+								</div>
+								<div className="flex flex-row ">
+									<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
+										2023.11.24
+									</div>
+									<AmendBtn />
+									<DeleteBtn />
+								</div>
+							</div>
+						))}
+					</div>
+				) : (
+					<></>
+				)}
+
+				{/* 댓글 등록 파트  */}
+				{is2CHide ? <EditComment /> : <></>}
+			</div>
+		</div>
+	);
+};
+
+export default Comment;

--- a/src/components/comment/EditComment.tsx
+++ b/src/components/comment/EditComment.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+import Temp2 from "@/assets/img/seeallareas.png";
+import Button, { btnAttributes } from "@/common/button/Button";
+
+const EditComment = () => {
+	const [isComment, setIsComment] = useState(
+		"댓글을 작성하고 있는 상황입니다. ",
+	);
+	const btnInfo: btnAttributes = {
+		text: "등록하기",
+		type: "square",
+		width: "172px",
+		position: "end",
+	};
+
+	return (
+		<div className="flex flex-row items-center justify-between h-32 px-2 py-5 my-2 border-2 rounded-lg border-MAIN_COLOR">
+			<img src={Temp2} alt="userImage" className="rounded-full w-14 h-14" />
+
+			<form className="flex items-center justify-center flex-1 h-full my-2 ml-3">
+				<textarea
+					name="comment"
+					className="w-full h-full px-2 py-2 min-h-18 bg-zinc-100"
+					value={isComment}
+					onChange={(e) => setIsComment(e.target.value)}
+				/>
+			</form>
+			<Button btnInfo={btnInfo} />
+		</div>
+	);
+};
+
+export default EditComment;

--- a/src/components/comment/HideComment.tsx
+++ b/src/components/comment/HideComment.tsx
@@ -1,0 +1,33 @@
+import ArrowDown from "@/assets/svg/ArrowDown";
+import ArrowUp from "@/assets/svg/ArrowUp";
+
+export interface hideTypes {
+	type: "hide" | "show";
+	onClick: () => void;
+}
+
+const HideComment = ({ type, onClick }: hideTypes) => {
+	const textStyle =
+		"text-sm text-ETC_COLOR hover:font-semibold cursor-pointer flex flex-row items-center";
+	const commentLength = 3;
+
+	if (type === "hide") {
+		return (
+			<button className={textStyle} onClick={onClick}>
+				<ArrowUp width={"12px"} height={"12px"} />
+				댓글 숨기기
+			</button>
+		);
+	}
+
+	if (type === "show") {
+		return (
+			<button className={textStyle} onClick={onClick}>
+				<ArrowDown width={"12px"} height={"12px"} />
+				{`댓글 ${commentLength}개 보기`}
+			</button>
+		);
+	}
+};
+
+export default HideComment;

--- a/src/pages/DetailForum.tsx
+++ b/src/pages/DetailForum.tsx
@@ -1,0 +1,15 @@
+import Comment from "@/components/comment/Comment";
+
+const DetailForum = () => {
+	return (
+		<div className="flex flex-col min-w-[1200px] max-w-[1200px] text-BASIC_BLACK mb-20">
+			<div className="bg-yellow-200">상단 부분</div>
+			<div className="pt-2 pb-10 border-b-2 bg-LINE_POINT_COLOR h-96 border-BASIC_BLACK">
+				본문 내용 입니다.
+			</div>
+			<Comment />
+		</div>
+	);
+};
+
+export default DetailForum;


### PR DESCRIPTION
# 개요
여행 포럼 디테일 페이지 댓글 컴포넌트 생성 

# 작업 사항 
- 댓글 컴포넌트 생성 
- 댓글 쓰기 클릭 시 댓글 등록 컴포넌트 생성 
- 댓글 보기 클릭 시 대댓글 리스트 드롭 다운 형식으로 등작 
- 상단에 새 댓글 등록 부분 생성

# 특이 사항
- 드롭 다운 시 animation 적용 예정 (추후)

# 미리 보기
<img width="1024" alt="스크린샷 2023-12-06 오전 1 28 01" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/2614bdb1-3e32-4f39-a619-a4138bede01f">
<img width="1050" alt="스크린샷 2023-12-06 오전 1 27 50" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/4d87087b-c55c-4ee5-8282-6c450388c3f1">

