### PR TITLE
Style: 헤더의 mousover 드롭다운 이벤트 삭제

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -56,10 +56,6 @@ const Header = () => {
 						<button
 							className={navBtn}
 							onBlur={onBlur}
-							onMouseEnter={() => {
-								setIsOpen(true);
-								setNavType(true);
-							}}
 							onClick={() => openNav("region")}
 						>
 							지역별 여행
@@ -67,10 +63,6 @@ const Header = () => {
 						<button
 							className={navBtn}
 							onBlur={onBlur}
-							onMouseEnter={() => {
-								setIsOpen(true);
-								setNavType(false);
-							}}
 							onClick={() => openNav(null)}
 						>
 							테마별 여행


### PR DESCRIPTION
# 개요
Header 의 상단 메뉴 탭에 mousOver 시 세부 메뉴 탭 드롭다운 되는 이벤트 제거 

# 작업 사항
- 각 메뉴 탭에 mousOver 이벤트 삭제 
- UX 적으로 불편하기 때문에 제거했습니다. 