### PR TITLE
Style: 헤더의 토글 버튼 동작 구현

### DIFF
--- a/src/components/header/DarkToggle.tsx
+++ b/src/components/header/DarkToggle.tsx
@@ -1,14 +1,36 @@
+import { useState } from "react";
 import Sun from "@/assets/svg/Sun";
 import Moon from "@/assets/svg/Moon";
 
 const DarkToggle = () => {
+	const [isDark, setIsDark] = useState(false);
+
+	const handleDarkToggle = () => {
+		setIsDark(!isDark);
+	};
+
+	const toggleX = isDark ? `translate-x-11` : "after:-translate-x-10";
+	const moonColor = isDark ? "#FAFAFA" : "#1C274C";
+	const sunColor = isDark ? "#1C274C" : "#FAFAFA";
+
 	return (
-		<div className="w-[77px] h-[29px] rounded-full bg-LINE_POINT_COLOR flex-row flex items-center">
-			<div className="w-[38px] rounded-full h-full p-auto bg-MAIN_COLOR drop-shadow-toggle flex items-center justify-center">
-				<Sun fillColor={"#FAFAFA"} width={"18px"} height={"18px"} />
+		<div className="relative w-[77px] h-[29px] rounded-full bg-LINE_POINT_COLOR flex-row flex items-center justify-between ">
+			<span
+				className={`transition duration-300 absolute z-10 w-[32px] p-auto h-full bg-MAIN_COLOR flex items-center justify-center rounded-full drop-shadow-toggle ${toggleX}`}
+			></span>
+
+			<div
+				className="z-30 flex items-center justify-center px-1.5 "
+				onClick={handleDarkToggle}
+			>
+				<Sun fillColor={sunColor} width={"20px"} height={"20px"} />
 			</div>
-			<div className="w-[38px] p-auto flex items-center justify-center">
-				<Moon fillColor={"#333333"} width={"18px"} height={"18px"} />
+
+			<div
+				className="z-30 flex items-center justify-center px-1.5"
+				onClick={handleDarkToggle}
+			>
+				<Moon fillColor={moonColor} width={"20px"} height={"20px"} />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
# 개요
헤더의 다크모드 라이트모드 기능 구현 예정인 토글의 동작 구현 PR

# 작업 사항
- useState 사용해서 <span> 파랑색 버튼의 위치 조정
- 삼항 연산자를 이용해서 각 SVG 아이콘의 색상 조정 

# 미리 보기 
<img width="228" alt="스크린샷 2023-12-08 오후 1 29 46" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/fd4345ee-c01d-4dfa-8242-8835c2b85b58">
<img width="216" alt="스크린샷 2023-12-08 오후 1 29 41" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/f99ea571-4295-4bb5-b97a-242b1dbb209d">
