### PR TITLE
Feat: 여행 포럼 상세 페이지의 댓글 컴포넌트 데이터 get 요청 기능 구현

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,30 +1,19 @@
 import React from "react";
 import { RecoilRoot } from "recoil";
-import {
-	QueryClientProvider,
-	QueryClient,
-	// QueryCache,
-} from "@tanstack/react-query";
-// import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 type ProvidersType = {
 	children: React.ReactNode;
 };
 
 const Providers = ({ children }: ProvidersType) => {
-	//const queryCache = new QueryCache();
-	const queryClient = new QueryClient({
-		defaultOptions: {
-			// queries: {
-			// 	suspense: true, - 실험적
-			// },
-		},
-	});
+	const queryClient = new QueryClient({});
 
 	return (
 		<RecoilRoot>
 			<QueryClientProvider client={queryClient}>
-				{/* <ReactQueryDevtools initialIsOpen={false} /> */}
+				<ReactQueryDevtools initialIsOpen={false} />
 				{children}
 			</QueryClientProvider>
 		</RecoilRoot>

--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import Temp from "@/assets/img/temp.png";
 import DeleteBtn from "@/common/button/DeleteBtn";
@@ -6,19 +7,63 @@ import AmendBtn from "@/common/button/AmendBtn";
 import HideComment from "@/components/comment/HideComment";
 import EditComment from "./EditComment";
 import ArrowComment from "@/assets/svg/ArrowComment";
+import axios from "axios";
+
+interface CommentReTypes {
+	articleId: number;
+	children: null;
+	commentId: number;
+	content: string;
+	createdAt: string;
+	parentId: number;
+	writeId: number;
+	writerNickname: string;
+}
+
+interface CommentTypes {
+	articleId: number;
+	children: CommentReTypes[];
+	commentId: number;
+	content: string;
+	createdAt: string;
+	parendId: null;
+	writerId: number;
+	writerNickname: string;
+}
 
 const Comment = () => {
 	const [isHide, setIsHide] = useState(false);
 	const [is2CHide, setIs2CHide] = useState(false);
-	// const isWrite2C = is2CHide ? "댓글 취소" : "댓글 쓰기";
+	const [editCommitId, setEditCommentId] = useState<number | null>(null);
+	//여기 하던 중 isLenth 여부 설정
+	const isLength = 3;
+	// const [commentData, setCommentData] = useState<null | CommentTypes[]>(null);
+	const getComments = async () => {
+		try {
+			const response = await axios.get("http://localhost:5000/comments");
+			// setCommentData(response.data);
+			return response.data;
+		} catch (err) {
+			throw new Error(`Err getComments ${err}`);
+		}
+	};
+	const { isPending, isError, data, error } = useQuery({
+		queryKey: ["comments"],
+		queryFn: getComments,
+	});
+	console.log(data);
 
 	const handleHideComment = () => {
 		setIsHide(!isHide);
 	};
 
-	const handle2CHide = () => {
+	const handle2CHide = (commentId: number) => {
+		setEditCommentId(commentId);
 		setIs2CHide(!is2CHide);
 	};
+
+	if (isPending) return <span>Loading...</span>;
+	if (isError) return <span>Error: {error.message}</span>;
 
 	return (
 		<div className="py-5 ">
@@ -26,68 +71,97 @@ const Comment = () => {
 			<EditComment />
 			{/* 댓글 내용 파트 */}
 			<div className="py-3 mt-10 border-y-2 border-LIGHT_GRAY_COLOR">
-				<div className="flex flex-row justify-between px-2 py-2 ">
-					<img src={Temp} alt="userImage" className="rounded-full w-14 h-14" />
-					<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
-						<div className="text-lg font-semibold">리랑이</div>
-						<div className="">본문 내용 섹션 입니다. 라랄랄라랄랄랄랄ㄹ</div>
-					</div>
-					<div className="flex flex-row ">
-						<div className="mx-3 text-sm text-DARK_GRAY_COLOR">2023.11.24</div>
-						<AmendBtn />
-						<DeleteBtn />
-					</div>
-				</div>
-
-				<div className="flex flex-row my-3">
-					{isHide ? (
-						<HideComment type={"hide"} onClick={handleHideComment} />
-					) : (
-						<HideComment type={"show"} onClick={handleHideComment} />
-					)}
-					<button
-						className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
-						onClick={handle2CHide}
-					>
-						{is2CHide ? "댓글 취소" : "댓글 쓰기"}
-					</button>
-				</div>
-				{/* 대댓글 */}
-				{isHide ? (
-					<div className="ml-10 bg-LINE_POINT_COLOR ">
-						{Array.from(Array(2), (_, idx) => (
+				{data &&
+					data.map((comment: CommentTypes) => (
+						<div key={comment.commentId}>
 							<div
-								key={idx}
-								className="flex flex-row justify-between px-2 py-2 my-1 border-b border-b-LIGHT_GRAY_COLOR"
+								key={`comment-actions-${comment.commentId}`}
+								className="flex flex-row justify-between px-2 py-2 "
 							>
-								<ArrowComment width={"25px"} height={"25px"} />
 								<img
 									src={Temp}
 									alt="userImage"
-									className="ml-3 rounded-full w-14 h-14"
+									className="rounded-full w-14 h-14"
 								/>
 								<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
-									<div className="text-lg font-semibold">리랑이</div>
-									<div className="">
-										본문 내용 섹션 입니다. 라랄랄라랄랄랄랄ㄹ
+									<div className="text-lg font-semibold">
+										{comment.writerNickname}
 									</div>
+									<div className="">{comment.content}</div>
 								</div>
 								<div className="flex flex-row ">
 									<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
-										2023.11.24
+										{comment.createdAt}
 									</div>
 									<AmendBtn />
 									<DeleteBtn />
 								</div>
 							</div>
-						))}
-					</div>
-				) : (
-					<></>
-				)}
+							{/* 대댓글 - 숨김- */}
+							<div className="flex flex-row my-3">
+								{comment.children.length !== 0 ? (
+									<HideComment
+										isHide={isHide}
+										onClick={handleHideComment}
+										isLength={isLength}
+									/>
+								) : (
+									<></>
+								)}
+								<button
+									key={`comment-button-${comment.commentId}`}
+									className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
+									onClick={() => handle2CHide(comment.commentId)}
+								>
+									{is2CHide && editCommitId === comment.commentId
+										? "댓글 취소"
+										: "댓글 쓰기"}
+								</button>
+							</div>
 
-				{/* 댓글 등록 파트  */}
-				{is2CHide ? <EditComment /> : <></>}
+							{/* 대댓글 */}
+							{isHide ? (
+								<div className="ml-10 bg-LINE_POINT_COLOR ">
+									{comment.children.length !== 0 &&
+										comment.children.map((el: CommentReTypes) => (
+											<div
+												key={el.commentId}
+												className="flex flex-row justify-between px-2 py-2 my-1 border-b border-b-LIGHT_GRAY_COLOR"
+											>
+												<ArrowComment width={"25px"} height={"25px"} />
+												<img
+													src={Temp}
+													alt="userImage"
+													className="ml-3 rounded-full w-14 h-14"
+												/>
+												<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+													<div className="text-lg font-semibold">
+														{el.writeId}
+													</div>
+													<div className="">{el.content}</div>
+												</div>
+												<div className="flex flex-row ">
+													<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
+														{el.createdAt}
+													</div>
+													<AmendBtn />
+													<DeleteBtn />
+												</div>
+											</div>
+										))}
+								</div>
+							) : (
+								<></>
+							)}
+
+							{/* 댓글 등록 파트  */}
+							{is2CHide && editCommitId === comment.commentId ? (
+								<EditComment />
+							) : (
+								<></>
+							)}
+						</div>
+					))}
 			</div>
 		</div>
 	);

--- a/src/components/comment/HideComment.tsx
+++ b/src/components/comment/HideComment.tsx
@@ -2,16 +2,17 @@ import ArrowDown from "@/assets/svg/ArrowDown";
 import ArrowUp from "@/assets/svg/ArrowUp";
 
 export interface hideTypes {
-	type: "hide" | "show";
+	isHide: boolean;
 	onClick: () => void;
+	isLength?: null | number;
 }
 
-const HideComment = ({ type, onClick }: hideTypes) => {
+const HideComment = ({ isHide, onClick, isLength }: hideTypes) => {
 	const textStyle =
 		"text-sm text-ETC_COLOR hover:font-semibold cursor-pointer flex flex-row items-center";
-	const commentLength = 3;
+	// const commentLength = 3;
 
-	if (type === "hide") {
+	if (isHide === true) {
 		return (
 			<button className={textStyle} onClick={onClick}>
 				<ArrowUp width={"12px"} height={"12px"} />
@@ -20,11 +21,11 @@ const HideComment = ({ type, onClick }: hideTypes) => {
 		);
 	}
 
-	if (type === "show") {
+	if (isHide === false) {
 		return (
 			<button className={textStyle} onClick={onClick}>
 				<ArrowDown width={"12px"} height={"12px"} />
-				{`댓글 ${commentLength}개 보기`}
+				{`댓글 ${isLength}개 보기`}
 			</button>
 		);
 	}


### PR DESCRIPTION
# 개요
여행 포럼 상세 페이지에서 댓글 컴포넌트 데이터 받아오는 react-query get 요청 구현 및
댓글 데이터에 따른 코드 수정

# 작업 사항
- react-Query 설정으로 get 요청 (json-server 임시 데이터 사용) 
- map으로 데이터 받아오면서 댓글 리스트 구현 
- 대댓글 여부에 따른 댓글 보여주기 | 댓글 숨기기 수정 
- 하나의 상태가 아닌 각 commentId로 개별 리스트에 접근하여 댓글 쓰기 버튼 클릭 시 해당 리스트 아래에만 댓글 등록 컴포넌트 생성 


# 예외 사항
- 입력 받은 날짜 데이터 이쁘게 변경하는 작업 필요. 

# 미리 보기 
<img width="913" alt="스크린샷 2023-12-11 오후 9 24 17" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/302b65d6-24fe-40f4-ae31-3ddb137a684a">
