### PR TITLE
Style: 헤더 반응형 작업 및 로그인여부에 따른 변경 적용

### DIFF
--- a/src/assets/svg/Close.tsx
+++ b/src/assets/svg/Close.tsx
@@ -1,6 +1,7 @@
 import { SVG } from "@/types/svg";
 
 const Close = ({ fillColor, width, height }: SVG) => {
+	fillColor = fillColor ? `${fillColor}` : "#222222";
 	return (
 		<svg
 			width={width}

--- a/src/assets/svg/Hamburger.tsx
+++ b/src/assets/svg/Hamburger.tsx
@@ -1,0 +1,38 @@
+import { SVG } from "@/types/svg";
+
+const Hamburger = ({ fillColor, width, height }: SVG) => {
+	fillColor = fillColor ? `${fillColor}` : "#000000";
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox="-0.5 0 25 25"
+			fill="none"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				d="M2 12.32H22"
+				stroke={fillColor}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M2 18.32H22"
+				stroke={fillColor}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+			<path
+				d="M2 6.32001H22"
+				stroke={fillColor}
+				strokeWidth="1.5"
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+};
+
+export default Hamburger;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -5,12 +5,14 @@ import Topnav from "./Topnav";
 import Bell from "@/assets/svg/Bell";
 import StoreNoti from "../notification/StoreNoti";
 import { Link } from "react-router-dom";
+import Mmenu from "./Mmenu";
 
 const Header = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [navType, setNavType] = useState<boolean | undefined>(undefined);
 	const [isNotifi, setIsNotifi] = useState(false);
 	const onSubMenuClose = () => setIsOpen(false);
+	const tempLogin = true; //임시 로그인 상태 설정
 
 	const navBtn =
 		"h-full hover:bg-BASIC_BLACK hover:text-BASIC_WHITE px-9 focus:bg-BASIC_BLACK focus:text-BASIC_WHITE ";
@@ -34,38 +36,71 @@ const Header = () => {
 	};
 
 	// 세부메뉴탭 보여질 때 border bottom 선과 메뉴탭 배경 색상 일치시키는 클래스
-	let headerWrapperClass = "w-full h-[130px] bg-BASIC_WHITE border-b-2 border-LIGHT_GRAY_COLOR flex flex-col";
-	if(isOpen){
-		headerWrapperClass = "w-full h-[130px] bg-BASIC_WHITE border-b-2 border-BASIC_BLACK flex flex-col";
+	let headerWrapperClass =
+		"w-full h-[130px] bg-BASIC_WHITE border-b-2 border-LIGHT_GRAY_COLOR flex flex-col";
+	if (isOpen) {
+		headerWrapperClass =
+			"w-full h-[130px] bg-BASIC_WHITE border-b-2 border-BASIC_BLACK flex flex-col";
 	}
 
 	return (
 		<>
 			<div className={headerWrapperClass}>
 				<div className="flex justify-end w-full py-3 border-b-2 border-LIGHT_GRAY_COLOR text-LIGHT_GRAY_COLOR">
-					<DarkToggle />
-					<button className="relative flex ml-7" onClick={handleNotification}>
-						<Bell fillColor={"#575353"} width={"28px"} height={"28px"} />
-						<span className="relative top-0.5 flex w-2 h-2 right-3">
-							<span className="absolute inline-flex w-full h-full bg-red-400 rounded-full opacity-75 animate-ping"></span>
-							<span className="relative inline-flex w-2 h-2 rounded-full bg-POINT_COLOR"></span>
-						</span>
-					</button>
-					{isNotifi && <StoreNoti />}
-					<Link to={'/login'}>
-						<button className="px-9 hover:text-BASIC_BLACK">로그인</button>
-					</Link>
-					<Link to={'/signup'}>
-						<button className="px-9 hover:text-BASIC_BLACK">회원가입</button>
-					</Link>
+					<div className="ml-3">
+						<DarkToggle />
+					</div>
+
+					{tempLogin ? (
+						<>
+							<button
+								className="flex justify-end flex-1 md:flex-none ml-7"
+								onClick={handleNotification}
+							>
+								<div className="flex realtive">
+									<Bell fillColor={"#575353"} width={"28px"} height={"28px"} />
+									<span className="relative top-0.5 flex w-2 h-2 right-3">
+										<span className="absolute inline-flex w-full h-full bg-red-400 rounded-full opacity-75 animate-ping"></span>
+										<span className="relative inline-flex w-2 h-2 rounded-full bg-POINT_COLOR"></span>
+									</span>
+								</div>
+							</button>
+							{isNotifi && <StoreNoti />}
+							<button className="px-5 hover:text-BASIC_BLACK whitespace-nowrap">
+								<Link to={"/mypage"}>마이페이지</Link>{" "}
+							</button>
+							<button className="px-5 hover:text-BASIC_BLACK whitespace-nowrap">
+								로그아웃
+							</button>
+						</>
+					) : (
+						<>
+							<Link to={"/login"}>
+								<button className="px-5 hover:text-BASIC_BLACK whitespace-nowrap">
+									로그인
+								</button>
+							</Link>
+							<Link to={"/signup"}>
+								<button className="px-5 hover:text-BASIC_BLACK whitespace-nowrap">
+									회원가입
+								</button>
+							</Link>
+						</>
+					)}
 				</div>
-				<div className="flex items-center justify-between text-2xl font-bold grow text-BASIC_BLACK">
-					<Link to={'/'}>
-						<div className="text-4xl text-MAIN_COLOR px-9 font-bolder" onClick={onSubMenuClose}>
+				<div className="flex items-center justify-between text-2xl font-bold grow text-BASIC_BLACK ">
+					<Link to={"/"}>
+						<div
+							className="pl-3 text-4xl text-MAIN_COLOR md:px-9 font-bolder"
+							onClick={onSubMenuClose}
+						>
 							TRIPTRIP
 						</div>
 					</Link>
-					<div className="items-center h-full whitespace-nowrap">
+
+					{/* 여행 대 메뉴 탭 */}
+					<Mmenu openNav={openNav} />
+					<div className="items-center hidden h-full md:block whitespace-nowrap">
 						<button
 							className={navBtn}
 							// 링크 이동 확인하느라 포커스 해제 잠시 주석처리 하겠습니다!
@@ -82,8 +117,8 @@ const Header = () => {
 						>
 							테마별 여행
 						</button>
-						<Link to={'/forum'}>
-							<button 
+						<Link to={"/forum"}>
+							<button
 								className={navBtn}
 								// 만들어두셨던 onBlur 이름만 바꿔서 로고, 여행포럼 클릭할 땐 서브메뉴 안보이게 설정했어요!
 								// 임시방편이라 원하시는 쪽으로 수정 보셔요!!!!!

--- a/src/components/header/Mmenu.tsx
+++ b/src/components/header/Mmenu.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import Hamburger from "@/assets/svg/Hamburger";
+import Close from "@/assets/svg/Close";
+
+type NavTypes = {
+	openNav: (trip: null | string) => void;
+};
+
+const Mmenu = ({ openNav }: NavTypes) => {
+	const [isOpen, setIsOpen] = useState(false);
+
+	return (
+		<div className="md:hidden">
+			<div className="pr-5">
+				<button onClick={() => setIsOpen(!isOpen)}>
+					{isOpen ? (
+						<Close width={"38px"} height={"38px"} />
+					) : (
+						<Hamburger width={"42px"} height={"42px"} />
+					)}
+				</button>
+			</div>
+			{isOpen && (
+				<div className="absolute left-0 flex flex-col w-screen shadow-md bg-BASIC_WHITE top-32">
+					<button
+						className="py-8 border-b font-xl border-LIGHT_GRAY_COLOR"
+						onClick={() => openNav("region")}
+					>
+						지역별 여행
+					</button>
+					<button
+						className="py-8 border-b font-xl border-LIGHT_GRAY_COLOR"
+						onClick={() => openNav(null)}
+					>
+						테마별 여행
+					</button>
+					<button className="py-8 font-xl" onClick={() => openNav("/forum")}>
+						여행 포럼
+					</button>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Mmenu;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+html, body {
+    width: 100%;
+    overflow-x: hidden;
+}
+
 @layer components {
     .blue_squareBtn {
         @apply py-2 px-5 my-3 mx-2 text-center bg-MAIN_COLOR text-BASIC_WHITE hover:bg-BTN_HOVER_COLOR rounded-lg font-medium;


### PR DESCRIPTION
# 개요
헤더 반응형 작업 및 로그인 여부에 따라 (마이페이지, 로그아웃, 알림 벨 ) | (로그인, 회원가입 ) 변경 설정

# 작업 사항
- 헤더 반응형 
    - 데스크톱 이하 사이즈에서는 전부 햄버거 토글로 메뉴 바 변경
    - 데스크톱 이하 사이즈에서는 다크모드 토글 왼쪽으로 이동 
- 임시 로그인 상태 tempLogin (boolean) 값에 따라 상단 부 (마이페이지, 로그아웃, 알림 벨 ) | (로그인, 회원가입 ) 변경 작업 

# 미리 보기 
<img width="235" alt="스크린샷 2023-12-12 오후 3 17 02" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/8e1b5587-5610-4275-90d7-0612aba7ced1">
<img width="1056" alt="스크린샷 2023-12-12 오후 3 16 57" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/b2ca828f-09b6-4cd9-aac4-2cfb6af8b59e">
<img width="244" alt="스크린샷 2023-12-12 오후 3 43 29" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/7ff1278b-4952-49a1-aa20-4641f55f58f3">
<img width="1012" alt="스크린샷 2023-12-12 오후 3 43 50" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/382c6a11-17f1-4a9f-99bc-0726d0d32e1d">

