### PR TITLE
Feat: 댓글 CRUD 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Mypage from "./pages/Mypage";
 import Test from "./components/Test";
 
 function App() {
+	window.localStorage.setItem("memberId", "1");
 	return (
 		<BrowserRouter>
 			<Header />

--- a/src/common/button/AmendBtn.tsx
+++ b/src/common/button/AmendBtn.tsx
@@ -1,5 +1,21 @@
-const AmendBtn = () => {
-	return <div className="mx-2 text-sm text-DARK_GRAY_COLOR">수정</div>;
+import { ParentInfo } from "@/components/comment/EditComment";
+
+interface AmendCommentTypes extends ParentInfo {
+	onClick: () => void;
+	parentInfo: [number, number | null, number | null];
+}
+
+const AmendBtn = ({ onClick, parentInfo }: AmendCommentTypes) => {
+	//본인 확인 여부
+	console.log(`${parentInfo}`);
+	return (
+		<div
+			className="mx-2 text-sm cursor-pointer text-DARK_GRAY_COLOR"
+			onClick={onClick}
+		>
+			수정
+		</div>
+	);
 };
 
 export default AmendBtn;

--- a/src/common/button/Button.tsx
+++ b/src/common/button/Button.tsx
@@ -1,3 +1,6 @@
+import BasicModal, { ModalAttributes } from "@/components/modal/BasicModal";
+import { useState } from "react";
+
 export interface btnAttributes {
 	width: string;
 	// height: string;
@@ -7,6 +10,13 @@ export interface btnAttributes {
 	border?: string;
 	position?: string;
 	type: "circle" | "square";
+	//상위에서 로그인 상태 일 때 실행되어야 할 함수
+	onClick?: (() => void) | void | undefined;
+	//현재 로그인 상태 여부 확인
+	isLogin?: boolean;
+	//로그인 버튼으로 사용할 거니 여부
+	loginBtnType?: true;
+	modal?: ModalAttributes | undefined;
 }
 
 interface btnTypes {
@@ -14,7 +24,22 @@ interface btnTypes {
 }
 
 const Button = ({ btnInfo }: btnTypes) => {
-	const { width, bgColor, textColor, border, position, text, type } = btnInfo;
+	const [isOpen, setIsOpen] = useState(false);
+
+	const {
+		width,
+		bgColor,
+		textColor,
+		border,
+		position,
+		text,
+		type,
+		onClick,
+		isLogin,
+		loginBtnType,
+		modal,
+	} = btnInfo;
+
 	//console.log(btnInfo);
 	const basicStyle = type === "circle" ? "blue_circleBtn" : `blue_squareBtn`;
 	const bg = bgColor ? `bg-${bgColor}` : "";
@@ -23,11 +48,46 @@ const Button = ({ btnInfo }: btnTypes) => {
 	const tColor = textColor ? `text-${textColor}` : "";
 	const btnStyle = `${basicStyle} w-[${width}] ${float} ${bg} ${borderStyle} ${tColor} `;
 	//console.log(btnStyle);
-	//circle | square
+
+	//noClick : 모달 닫는 함수 추가
+	const modifiedModal: ModalAttributes = {
+		// 타입 강제 할당
+		// ...(modal as ModalAttributes),
+		...modal!,
+		noClick: () => setIsOpen(false),
+	};
+	// console.log(modifiedModal);
+	const checkLogin = () => {
+		if (isLogin) {
+			//로그인 상태 인 경우 원하는 함수 설정
+			console.log("로그인 된 상태로 함수 실행!");
+			onClick?.();
+		} else {
+			// 알림 모달 오픈
+			setIsOpen(true);
+			console.log("모달 버튼 오픈 실행 !");
+		}
+	};
+
+	const handleButtonClick = () => {
+		if (loginBtnType && modal) {
+			// 로그인 확인용 버튼으로 설정했을 경우
+
+			console.log("로그인 확인용 버튼 클릭 ");
+			checkLogin();
+		} else {
+			// 별도의 클릭 버튼으로 설정했을 경우
+			onClick?.();
+			console.log("일반 버튼 클릭  ");
+		}
+	};
 
 	return (
 		<div>
-			<button className={btnStyle}>{text}</button>
+			<button className={btnStyle} onClick={handleButtonClick}>
+				{text}
+			</button>
+			{isOpen && modal ? <BasicModal modal={modifiedModal} /> : null}
 		</div>
 	);
 };

--- a/src/common/button/DeleteBtn.tsx
+++ b/src/common/button/DeleteBtn.tsx
@@ -1,5 +1,39 @@
-const DeleteBtn = () => {
-	return <div className="mx-2 text-sm text-DARK_GRAY_COLOR">삭제</div>;
+// import { useMutation } from "@tanstack/react-query";
+// import axios from "axios";
+
+type DeleteCommentTypes = {
+	commentId: number;
+};
+
+const DeleteBtn = ({ commentId }: DeleteCommentTypes) => {
+	// const mutation = useMutation({
+	// 	mutationFn: () => {
+	// 		return axios.delete(`http://localhost:5000/comments/${commentId}`, {
+	// 	headers: {
+	// 		Authorization: `Bearer ${authToken}`   //쿠키나 전역에서 가져올 예정
+	// 	}
+	// });
+	// 	},
+	// });
+
+	//댓글 삭제 버튼
+	const handleDelete = async () => {
+		try {
+			// await mutation.mutateAsync();
+			console.log(`댓글 삭제 버튼 작덩 ${commentId}`);
+		} catch (error) {
+			throw new Error(`댓글 삭제 파트 ${error}`);
+		}
+	};
+
+	return (
+		<div
+			className="mx-2 text-sm cursor-pointer text-DARK_GRAY_COLOR"
+			onClick={handleDelete}
+		>
+			삭제
+		</div>
+	);
 };
 
 export default DeleteBtn;

--- a/src/components/comment/Comment.tsx
+++ b/src/components/comment/Comment.tsx
@@ -1,43 +1,45 @@
-import { useState } from "react";
+/* eslint-disable no-mixed-spaces-and-tabs */
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-
-import Temp from "@/assets/img/temp.png";
-import DeleteBtn from "@/common/button/DeleteBtn";
-import AmendBtn from "@/common/button/AmendBtn";
-import HideComment from "@/components/comment/HideComment";
-import EditComment from "./EditComment";
-import ArrowComment from "@/assets/svg/ArrowComment";
 import axios from "axios";
 
-interface CommentReTypes {
+import EditComment from "./EditComment";
+import CommentItem from "./commentItem";
+
+import ArrowComment from "@/assets/svg/ArrowComment";
+
+export interface CommentReTypes {
 	articleId: number;
 	children: null;
 	commentId: number;
 	content: string;
 	createdAt: string;
 	parentId: number;
-	writeId: number;
+	writerId: number;
 	writerNickname: string;
 }
 
-interface CommentTypes {
+export interface CommentTypes {
 	articleId: number;
-	children: CommentReTypes[];
+	children: CommentReTypes[] | null;
 	commentId: number;
 	content: string;
 	createdAt: string;
-	parendId: null;
+	parentId: null | number;
 	writerId: number;
 	writerNickname: string;
 }
 
 const Comment = () => {
-	const [isHide, setIsHide] = useState(false);
-	const [is2CHide, setIs2CHide] = useState(false);
-	const [editCommitId, setEditCommentId] = useState<number | null>(null);
-	//여기 하던 중 isLenth 여부 설정
-	const isLength = 3;
-	// const [commentData, setCommentData] = useState<null | CommentTypes[]>(null);
+	const [isHide, setIsHide] = useState<boolean>(false);
+	//props로 articleId 넘겨 받아야 함
+	const TarticleId = 1;
+
+	//대댓글 숨김 관리 -> Props -> CommentItem
+	const handleHideComment = () => {
+		setIsHide(!isHide);
+	};
+
 	const getComments = async () => {
 		try {
 			const response = await axios.get("http://localhost:5000/comments");
@@ -53,114 +55,45 @@ const Comment = () => {
 	});
 	console.log(data);
 
-	const handleHideComment = () => {
-		setIsHide(!isHide);
-	};
+	//중복 데이터 메모이제이션
+	const memoizedData = useMemo(() => data, [data]);
 
-	const handle2CHide = (commentId: number) => {
-		setEditCommentId(commentId);
-		setIs2CHide(!is2CHide);
-	};
-
-	if (isPending) return <span>Loading...</span>;
+	if (isPending)
+		return (
+			<span className="h-full mx-auto mt-5 text-xl font-semibol">
+				데이터를 불러오는 중입니다. 잠시만요!
+			</span>
+		);
 	if (isError) return <span>Error: {error.message}</span>;
 
 	return (
 		<div className="py-5 ">
-			{/* 댓글 등록 파트  */}
-			<EditComment />
+			{/* 새 댓글 등록 파트  */}
+			<EditComment parentInfo={[TarticleId, null, null]} />
 			{/* 댓글 내용 파트 */}
 			<div className="py-3 mt-10 border-y-2 border-LIGHT_GRAY_COLOR">
-				{data &&
-					data.map((comment: CommentTypes) => (
-						<div key={comment.commentId}>
-							<div
-								key={`comment-actions-${comment.commentId}`}
-								className="flex flex-row justify-between px-2 py-2 "
-							>
-								<img
-									src={Temp}
-									alt="userImage"
-									className="rounded-full w-14 h-14"
-								/>
-								<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
-									<div className="text-lg font-semibold">
-										{comment.writerNickname}
-									</div>
-									<div className="">{comment.content}</div>
-								</div>
-								<div className="flex flex-row ">
-									<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
-										{comment.createdAt}
-									</div>
-									<AmendBtn />
-									<DeleteBtn />
-								</div>
-							</div>
-							{/* 대댓글 - 숨김- */}
-							<div className="flex flex-row my-3">
-								{comment.children.length !== 0 ? (
-									<HideComment
-										isHide={isHide}
-										onClick={handleHideComment}
-										isLength={isLength}
-									/>
-								) : (
-									<></>
-								)}
-								<button
-									key={`comment-button-${comment.commentId}`}
-									className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
-									onClick={() => handle2CHide(comment.commentId)}
-								>
-									{is2CHide && editCommitId === comment.commentId
-										? "댓글 취소"
-										: "댓글 쓰기"}
-								</button>
-							</div>
-
-							{/* 대댓글 */}
-							{isHide ? (
-								<div className="ml-10 bg-LINE_POINT_COLOR ">
-									{comment.children.length !== 0 &&
-										comment.children.map((el: CommentReTypes) => (
-											<div
-												key={el.commentId}
-												className="flex flex-row justify-between px-2 py-2 my-1 border-b border-b-LIGHT_GRAY_COLOR"
-											>
-												<ArrowComment width={"25px"} height={"25px"} />
-												<img
-													src={Temp}
-													alt="userImage"
-													className="ml-3 rounded-full w-14 h-14"
-												/>
-												<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
-													<div className="text-lg font-semibold">
-														{el.writeId}
-													</div>
-													<div className="">{el.content}</div>
-												</div>
-												<div className="flex flex-row ">
-													<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
-														{el.createdAt}
-													</div>
-													<AmendBtn />
-													<DeleteBtn />
-												</div>
-											</div>
-										))}
-								</div>
-							) : (
-								<></>
-							)}
-
-							{/* 댓글 등록 파트  */}
-							{is2CHide && editCommitId === comment.commentId ? (
-								<EditComment />
-							) : (
-								<></>
-							)}
-						</div>
+				{memoizedData &&
+					memoizedData.map((comment: CommentTypes) => (
+						<>
+							<CommentItem
+								datas={comment}
+								key={comment.commentId}
+								isHide={isHide}
+								setIsHide={handleHideComment}
+								type={"origin"}
+							/>
+							{isHide && comment.children !== null
+								? comment.children.map((childComment: CommentTypes) => (
+										<div
+											key={`child-comment-${childComment.commentId}`}
+											className="flex flex-row justify-between px-2 ml-10 "
+										>
+											<ArrowComment width={"25px"} height={"25px"} />
+											<CommentItem datas={childComment} type={"child"} />
+										</div>
+								  ))
+								: null}
+						</>
 					))}
 			</div>
 		</div>

--- a/src/components/comment/CommentItem.tsx
+++ b/src/components/comment/CommentItem.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import AmendBtn from "@/common/button/AmendBtn";
+import { CommentTypes } from "./Comment";
+import DeleteBtn from "@/common/button/DeleteBtn";
+
+import Temp from "@/assets/img/temp.png";
+import EditComment from "./EditComment";
+import HideComment from "./HideComment";
+// import { useState } from "react";
+// import HideComment from "./HideComment";
+
+interface CommentItems {
+	datas: CommentTypes;
+	isHide?: boolean;
+	setIsHide?: () => void;
+	type: "origin" | "child";
+}
+
+const CommentItem = ({ datas, isHide, setIsHide, type }: CommentItems) => {
+	const [isEdit, setIsEdit] = useState(false);
+	// const [isHide, setIsHide] = useState(false);
+	const [is2CHide, setIs2CHide] = useState(false);
+	const [editCommitId, setEditCommentId] = useState<number | null>(null);
+	const MEMBER_ID = Number(window.localStorage.getItem("memberId"));
+
+	// const handleHideComment = () => {
+	// 	setIsHide(!isHide);
+	// };
+
+	const handle2CHide = (commentId: number) => {
+		setEditCommentId(commentId);
+		setIs2CHide(!is2CHide);
+	};
+
+	//css
+	const bgClass =
+		type === "child"
+			? "bg-LINE_POINT_COLOR flex-1 border-b border-b-LIGHT_GRAY_COLOR"
+			: "";
+
+	return (
+		<>
+			{isEdit ? (
+				<EditComment
+					parentInfo={[datas.articleId, datas.parentId, datas.commentId]}
+					editData={datas.content}
+					isEditMode={true}
+				/>
+			) : (
+				<div className={bgClass}>
+					<div
+						key={`comment-actions-${datas.commentId}`}
+						className="flex flex-row justify-between px-2 py-3"
+					>
+						<img
+							src={Temp}
+							alt="userImage"
+							className="rounded-full w-14 h-14"
+						/>
+						<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+							<div className="text-lg font-semibold">
+								{datas.writerNickname}
+							</div>
+							<div className="">{datas.content}</div>
+						</div>
+						<div className="flex flex-row ">
+							<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
+								{datas.createdAt}
+							</div>
+							{datas.writerId === MEMBER_ID ? (
+								<>
+									<AmendBtn
+										onClick={() => {
+											setIsEdit(!isEdit), console.log("수정 버튼 클릭");
+										}}
+										parentInfo={[
+											datas.articleId,
+											datas.parentId,
+											datas.commentId,
+										]}
+									/>
+									<DeleteBtn commentId={datas.commentId} />
+								</>
+							) : null}
+						</div>
+					</div>
+
+					{/* 댓글 하단 부 댓글 보기 | 댓글 쓰기 색션 */}
+					{type === "origin" ? (
+						<div className="flex flex-row mt-3 mb-1">
+							{datas.children !== null && datas.children.length !== 0 ? (
+								<HideComment
+									isHide={isHide as boolean}
+									onClick={setIsHide as () => void}
+									isLength={datas.children.length}
+								/>
+							) : (
+								<></>
+							)}
+							<button
+								key={`comment-button-${datas.commentId}`}
+								className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
+								onClick={() => handle2CHide(datas.commentId)}
+							>
+								{is2CHide && editCommitId === datas.commentId
+									? "댓글 취소"
+									: "댓글 쓰기"}
+							</button>
+						</div>
+					) : null}
+					{is2CHide && editCommitId === datas.commentId ? (
+						<EditComment
+							parentInfo={[datas.articleId, datas.parentId, datas.commentId]}
+						/>
+					) : (
+						<></>
+					)}
+				</div>
+			)}
+		</>
+	);
+};
+
+export default CommentItem;

--- a/src/components/comment/EditComment.tsx
+++ b/src/components/comment/EditComment.tsx
@@ -1,17 +1,82 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 import Temp2 from "@/assets/img/seeallareas.png";
 import Button, { btnAttributes } from "@/common/button/Button";
+import { ModalAttributes } from "../modal/BasicModal";
+// import axios from "axios";
 
-const EditComment = () => {
-	const [isComment, setIsComment] = useState(
-		"댓글을 작성하고 있는 상황입니다. ",
-	);
+export interface ParentInfo {
+	// articleId: number;
+	// parentId: number | null;
+	//  - null이면 오리진 , - number이면 대댓글
+	// commentId: number;
+	parentInfo: [number, number | null, number | null];
+	editData?: string;
+	isEditMode?: boolean;
+}
+
+const EditComment = ({ parentInfo, editData, isEditMode }: ParentInfo) => {
+	const [isComment, setIsComment] = useState(editData ? editData : "");
+	const tempLogin = true; //임시 전역 로그인 상태
+	console.log(parentInfo[0], parentInfo[1]);
+	console.log(editData);
+
+	//모달 -> Yes -> 로그인 이동
+	const navigate = useNavigate();
+	const linkLogin = () => {
+		navigate("/login");
+	};
+
+	//새 댓글 등록하는 함수
+	const sendNewComment = async () => {
+		try {
+			// axios.post("http://localhost:5000/comments", {
+			// 	articleId: parentInfo[0],
+			// 	parentId: parentInfo[1],
+			// 	content: isComment,
+			// });
+			console.log("새 댓글 등록 기능 작동!");
+			console.log(`등록 : ${isComment}`);
+			setIsComment("");
+		} catch (err) {
+			throw new Error(`Err ${err}`);
+		}
+	};
+
+	//댓글 수정 전달하는 함수
+	const amendComment = async () => {
+		try {
+			// axios.patch(`/api/comments/${commentId}`, {
+			// 	body: {
+			// 		content: 받아야 함 어디선가
+			// 	}
+			// });
+			console.log("댓글 수정하는 기능 작동!");
+			console.log(`수정 : ${isComment}`);
+			//이거 학고 페이지 업데이트?
+		} catch (err) {
+			throw new Error(`댓글 수정 버튼 에러 ${err}`);
+		}
+	};
+
+	//모달에 필요한 props
+	const modal: ModalAttributes = {
+		content: "로그인한 사용자만 작성 가능합니다. 이동하시겠습니까?",
+		yesClick: () => linkLogin(),
+	};
+
+	//버튼에 필요한 props
 	const btnInfo: btnAttributes = {
 		text: "등록하기",
 		type: "square",
 		width: "172px",
 		position: "end",
+
+		isLogin: tempLogin,
+		loginBtnType: true,
+		modal: modal,
+		onClick: isEditMode ? amendComment : sendNewComment,
 	};
 
 	return (
@@ -23,6 +88,7 @@ const EditComment = () => {
 					name="comment"
 					className="w-full h-full px-2 py-2 min-h-18 bg-zinc-100"
 					value={isComment}
+					placeholder={"댓글을 등록 해 주세요."}
 					onChange={(e) => setIsComment(e.target.value)}
 				/>
 			</form>

--- a/src/components/comment/EditComment.tsx
+++ b/src/components/comment/EditComment.tsx
@@ -80,7 +80,7 @@ const EditComment = ({ parentInfo, editData, isEditMode }: ParentInfo) => {
 	};
 
 	return (
-		<div className="flex flex-row items-center justify-between h-32 px-2 py-5 my-2 border-2 rounded-lg border-MAIN_COLOR">
+		<div className="flex flex-row items-center justify-between flex-1 h-32 px-2 py-5 my-2 border-2 rounded-lg border-MAIN_COLOR">
 			<img src={Temp2} alt="userImage" className="rounded-full w-14 h-14" />
 
 			<form className="flex items-center justify-center flex-1 h-full my-2 ml-3">

--- a/src/components/comment/HideComment.tsx
+++ b/src/components/comment/HideComment.tsx
@@ -10,7 +10,7 @@ export interface hideTypes {
 const HideComment = ({ isHide, onClick, isLength }: hideTypes) => {
 	const textStyle =
 		"text-sm text-ETC_COLOR hover:font-semibold cursor-pointer flex flex-row items-center";
-	// const commentLength = 3;
+	console.log(isHide);
 
 	if (isHide === true) {
 		return (

--- a/src/components/comment/Temp.tsx
+++ b/src/components/comment/Temp.tsx
@@ -1,0 +1,157 @@
+// const [isHide, setIsHide] = useState(false);
+// const [is2CHide, setIs2CHide] = useState(false);
+// const [editCommitId, setEditCommentId] = useState<number | null>(null);
+
+// const handleHideComment = () => {
+// 	setIsHide(!isHide);
+// };
+
+// const handle2CHide = (commentId: number) => {
+// 	setEditCommentId(commentId);
+// 	setIs2CHide(!is2CHide);
+// };
+
+{
+	/* 대댓글 - 숨김-
+			<div className="flex flex-row my-3 bg-yellow-300">
+				{datas.children.length !== 0 ? (
+					<HideComment
+						isHide={isHide}
+						onClick={handleHideComment}
+						isLength={datas.children.length}
+					/>
+				) : (
+					<></>
+				)}
+				<button
+					key={`comment-button-${datas.commentId}`}
+					className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
+					onClick={() => handle2CHide(datas.commentId)}
+				>
+					{is2CHide && editCommitId === datas.commentId
+						? "댓글 취소"
+						: "댓글 쓰기"}
+				</button>
+			</div> */
+}
+
+// <div key={comment.commentId}>
+
+{
+	/* <div
+								key={`comment-actions-${comment.commentId}`}
+								className="flex flex-row justify-between px-2 py-2 bg-yellow-200"
+							>
+								<img
+									src={Temp}
+									alt="userImage"
+									className="rounded-full w-14 h-14"
+								/>
+								<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+									<div className="text-lg font-semibold">
+										{comment.writerNickname}
+									</div>
+									<div className="">{comment.content}</div>
+								</div>
+								<div className="flex flex-row ">
+									<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
+										{comment.createdAt}
+									</div>
+									<AmendBtn
+										onClick={handleAmend}
+										parentInfo={[
+											comment.articleId,
+											comment.parentId,
+											comment.commentId,
+										]}
+									/>
+									<DeleteBtn commentId={comment.commentId} />
+								</div>
+							</div> */
+}
+
+{
+	/* 대댓글 - 숨김-
+							<div className="flex flex-row my-3 bg-yellow-300">
+								{comment.children.length !== 0 ? (
+									<HideComment
+										isHide={isHide}
+										onClick={handleHideComment}
+										isLength={comment.children.length}
+									/>
+								) : (
+									<></>
+								)}
+								<button
+									key={`comment-button-${comment.commentId}`}
+									className="ml-5 text-sm text-LIGHT_GRAY_COLOR hover:text-ETC_COLOR pointer-cursor"
+									onClick={() => handle2CHide(comment.commentId)}
+								>
+									{is2CHide && editCommitId === comment.commentId
+										? "댓글 취소"
+										: "댓글 쓰기"}
+								</button>
+							</div> */
+}
+
+{
+	/* 대댓글 */
+}
+{
+	/* {isHide ? (
+								<div className="ml-10 bg-LINE_POINT_COLOR ">
+									{comment.children.length !== 0 &&
+										comment.children.map((el: CommentReTypes) => (
+											<div
+												key={el.commentId}
+												className="flex flex-row justify-between px-2 py-2 my-1 border-b border-b-LIGHT_GRAY_COLOR"
+											>
+												<ArrowComment width={"25px"} height={"25px"} />
+												<img
+													src={Temp}
+													alt="userImage"
+													className="ml-3 rounded-full w-14 h-14"
+												/>
+												<div className="flex-1 w-9/12 ml-3 text-BASIC_BLACK">
+													<div className="text-lg font-semibold">
+														{el.writeId}
+													</div>
+													<div className="">{el.content}</div>
+												</div>
+												<div className="flex flex-row ">
+													<div className="mx-3 text-sm text-DARK_GRAY_COLOR">
+														{el.createdAt}
+													</div>
+													<AmendBtn
+														onClick={handleAmend}
+														parentInfo={[
+															el.articleId,
+															el.parentId,
+															el.commentId,
+														]}
+													/>
+													<DeleteBtn commentId={el.commentId} />
+												</div>
+											</div>
+										))}
+								</div>
+							) : (
+								<></>
+							)} */
+}
+
+{
+	/* 댓글 등록 파트 
+							{is2CHide && editCommitId === comment.commentId ? (
+								<EditComment
+									parentInfo={[
+										comment.articleId,
+										comment.parentId,
+										comment.commentId,
+									]}
+								/>
+							) : (
+								<></>
+							)} */
+}
+// </div>

--- a/src/components/modal/BasicModal.tsx
+++ b/src/components/modal/BasicModal.tsx
@@ -3,32 +3,32 @@ import { useState } from "react";
 export interface ModalAttributes {
 	title?: string;
 	content: string;
-	isClick: () => void;
+	noClick?: () => void;
+	yesClick?: () => void;
 }
 
-interface ModalTypes {
+export interface ModalTypes {
 	modal: ModalAttributes;
 }
 
 const BasicModal = ({ modal }: ModalTypes) => {
 	const [isSubmit] = useState(true);
-	const { title, content, isClick } = modal;
+	const { title, content, yesClick, noClick } = modal;
 	const btnStyle =
 		"p-3  mx-2 w-20 border border-BASIC_BLACK bg-BASIC_WHITE rounded-lg font-semibold hover:bg-MAIN_COLOR hover:border-0";
-	console.log(title);
-
+	// console.log(modal);
 	return (
 		<div className="fixed inset-0 z-10 flex items-end justify-center w-screen min-h-full p-4 overflow-y-auto text-center transition-opacity bg-gray-500 bg-opacity-75 sm:items-center sm:p-0">
 			<div className="relative px-10 pb-10 overflow-hidden text-left transition-all transform bg-white rounded-lg shadow-xl w-fit">
 				<div className="flex flex-col items-center">
-					{/* <div className="my-3 font-semibold">{title}</div> */}
+					<div className="my-3 font-semibold">{title}</div>
 					<div className="my-10 text-xl font-semibold">{content}</div>
 					{isSubmit && (
 						<div className="flex flex-row">
-							<button className={btnStyle} type="submit">
+							<button className={btnStyle} type="submit" onClick={yesClick}>
 								예
 							</button>
-							<button className={btnStyle} type="submit" onClick={isClick}>
+							<button className={btnStyle} type="submit" onClick={noClick}>
 								아니오
 							</button>
 						</div>


### PR DESCRIPTION
# 개요 
댓글 CRUD 기능 구현 

# 작업 사항 
- 댓글 등록 
    * 새 댓글 등록 시 로그인 여부 확인 후 새 댓글 추가 
<img width="385" alt="스크린샷 2023-12-14 오후 6 06 28" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/1be3555c-7451-4066-9b4a-8eadd69553c0">

- 댓글 수정 
    * 본인이 작성한 댓글 , 대댓글 만 수정  | 삭제 버튼이 보인다. 
    * 수정 클릭 시 댓글 수정 컴포넌트로 변경 
    * 댓글 수정 후 등록 시 로그인 여부 확인 후 수정된 댓글로 변경 
    * 이 부분에서 굳이 로그인 여부 추가 로직이 필요한가 싶지만 -> 추후 로직을 업데이트 예정 
<img width="372" alt="스크린샷 2023-12-14 오후 6 07 06" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/bb05848e-a679-4519-a3bb-d58cf2493fcd">

- 댓글 삭제 
   * 본인이 작성한 댓글 만 수정 | 삭제 버튼 보인다. 
   * 삭제 클릭 시 현재는 바로 댓글 삭제 -> 알림 모달 중간에 삽입 예정 
- 댓글 조회 
   * Comment 컴포넌트 분해 
```bash
   Comment
         ├── EditComment ( 새 댓글 등록)
         ├── CommentItem
         │       ├── EditComment  ( 댓글 수정)
         │       ├── HideComment ( 하단 부 댓글 숨기기 | 댓글 쓰기 ) 
         │       └── Editcomment   ( 대댓글 수정 용)
         └── CommentItem(대댓글 용)
```

# 예외 사항 
- 날짜 수정 예정 

# 미리 보기 
<img width="942" alt="스크린샷 2023-12-14 오후 6 12 38" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/3b3c7c8e-e228-4b46-aa99-4abefc3da33c">
<img width="980" alt="스크린샷 2023-12-14 오후 6 12 48" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/31859485-52aa-43a5-a25d-8136da3d8727">

