### PR TITLE
Feat: 포럼 전체 목록 페이지 데이터 조회 기능구현 및 버튼 컴포넌트 재 정립

### DIFF
--- a/src/common/button/Button.tsx
+++ b/src/common/button/Button.tsx
@@ -1,5 +1,6 @@
 import BasicModal, { ModalAttributes } from "@/components/modal/BasicModal";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 export interface btnAttributes {
 	width: string;
@@ -10,7 +11,7 @@ export interface btnAttributes {
 	border?: string;
 	position?: string;
 	type: "circle" | "square";
-	//상위에서 로그인 상태 일 때 실행되어야 할 함수
+	//로그인 상태 일 때 실행되어야 할 함수
 	onClick?: (() => void) | void | undefined;
 	//현재 로그인 상태 여부 확인
 	isLogin?: boolean;
@@ -37,8 +38,8 @@ const Button = ({ btnInfo }: btnTypes) => {
 		onClick,
 		isLogin,
 		loginBtnType,
-		modal,
 	} = btnInfo;
+	let { modal } = btnInfo;
 
 	//console.log(btnInfo);
 	const basicStyle = type === "circle" ? "blue_circleBtn" : `blue_squareBtn`;
@@ -47,7 +48,19 @@ const Button = ({ btnInfo }: btnTypes) => {
 	const float = position ? `float-${position}` : "";
 	const tColor = textColor ? `text-${textColor}` : "";
 	const btnStyle = `${basicStyle} w-[${width}] ${float} ${bg} ${borderStyle} ${tColor} `;
-	//console.log(btnStyle);
+	const navigate = useNavigate();
+	const linkLogin = () => {
+		navigate("/login");
+	};
+	const loginModal = {
+		content: "로그인 한 사용자만 사용할 수 있습니다. 로그인 하시겠습니까?",
+		noClick: () => setIsOpen(false),
+		yesClick: () => {
+			linkLogin(), console.log("로그인 페이지로 이동");
+		},
+	};
+	//입력 받는 모달이 있으면 해당 modal 속성 사용
+	modal = modal ? modal : loginModal;
 
 	//noClick : 모달 닫는 함수 추가
 	const modifiedModal: ModalAttributes = {
@@ -59,7 +72,7 @@ const Button = ({ btnInfo }: btnTypes) => {
 	// console.log(modifiedModal);
 	const checkLogin = () => {
 		if (isLogin) {
-			//로그인 상태 인 경우 원하는 함수 설정
+			//로그인 상태였을 때 실행하기를 원하는 함수 설정
 			console.log("로그인 된 상태로 함수 실행!");
 			onClick?.();
 		} else {
@@ -72,7 +85,6 @@ const Button = ({ btnInfo }: btnTypes) => {
 	const handleButtonClick = () => {
 		if (loginBtnType && modal) {
 			// 로그인 확인용 버튼으로 설정했을 경우
-
 			console.log("로그인 확인용 버튼 클릭 ");
 			checkLogin();
 		} else {

--- a/src/common/category/Category.tsx
+++ b/src/common/category/Category.tsx
@@ -1,11 +1,11 @@
 interface categoryTypes {
-	isEditor: "editor" | "user";
+	isEditor: "EDITOR" | "MEMBER";
 }
 
 const Category = ({ isEditor }: categoryTypes) => {
 	return (
 		<div className="">
-			{isEditor === "editor" ? (
+			{isEditor === "EDITOR" ? (
 				<div className="w-24 px-3 py-1 text-sm text-center rounded-2xl bg-SPECIAL_COLOR">
 					에디터 추천
 				</div>

--- a/src/components/comment/EditComment.tsx
+++ b/src/components/comment/EditComment.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+// import axios from "axios";
 
 import Temp2 from "@/assets/img/seeallareas.png";
 import Button, { btnAttributes } from "@/common/button/Button";
-import { ModalAttributes } from "../modal/BasicModal";
-// import axios from "axios";
 
 export interface ParentInfo {
 	// articleId: number;
@@ -21,12 +19,6 @@ const EditComment = ({ parentInfo, editData, isEditMode }: ParentInfo) => {
 	const tempLogin = true; //임시 전역 로그인 상태
 	console.log(parentInfo[0], parentInfo[1]);
 	console.log(editData);
-
-	//모달 -> Yes -> 로그인 이동
-	const navigate = useNavigate();
-	const linkLogin = () => {
-		navigate("/login");
-	};
 
 	//새 댓글 등록하는 함수
 	const sendNewComment = async () => {
@@ -54,16 +46,10 @@ const EditComment = ({ parentInfo, editData, isEditMode }: ParentInfo) => {
 			// });
 			console.log("댓글 수정하는 기능 작동!");
 			console.log(`수정 : ${isComment}`);
-			//이거 학고 페이지 업데이트?
+			//이거 하고 페이지 리랜더링 되는지 확인 필요.
 		} catch (err) {
 			throw new Error(`댓글 수정 버튼 에러 ${err}`);
 		}
-	};
-
-	//모달에 필요한 props
-	const modal: ModalAttributes = {
-		content: "로그인한 사용자만 작성 가능합니다. 이동하시겠습니까?",
-		yesClick: () => linkLogin(),
 	};
 
 	//버튼에 필요한 props
@@ -75,7 +61,6 @@ const EditComment = ({ parentInfo, editData, isEditMode }: ParentInfo) => {
 
 		isLogin: tempLogin,
 		loginBtnType: true,
-		modal: modal,
 		onClick: isEditMode ? amendComment : sendNewComment,
 	};
 

--- a/src/components/forumItems/ForumItem.tsx
+++ b/src/components/forumItems/ForumItem.tsx
@@ -1,27 +1,43 @@
 import Category from "@/common/category/Category";
 
-const ForumItem = () => {
+export interface ForumList {
+	articleId: number;
+	title: string;
+	writerId: number;
+	writerNickname: string;
+	writerRole: "MEMBER" | "EDITOR";
+	viewCount: number;
+	likeCount: number;
+	createdAt: string;
+}
+
+interface ForumItemTypes {
+	data: ForumList;
+}
+
+const ForumItem = ({ data }: ForumItemTypes) => {
 	const propsBg = "BAISC_WHITE";
 	const itemWrapper = `w-full whitespace-nowrap h-[70px] py-3 items-center flex flex-row 
 	justify-between text-lg font-base text-BASIC_BLACK border-b border-LIGHT_GRAY_COLOR bg-${propsBg} 
 	hover:font-bold hover:cursor-pointer`;
-	const isEditor = "editor";
 
 	return (
 		<div className={itemWrapper}>
 			<div className="grid place-items-center basis-1/6 bg-text-POINT_COLOR">
-				<Category isEditor={isEditor} />
+				<Category isEditor={data.writerRole} />
 			</div>
 			<div className="px-3 basis-3/6">
-				에디터 소개하는 강릉 여행 ~ <span className="text-sm">(5)</span>
+				{data.title}
+				<span className="text-sm">(5)</span>
+				{/* PS. 혹시 댓글 갯수도 받을 수 있을까..? 12/14 혜진 고민*/}
 			</div>
 			<div className="basis-1/6 ">
 				{/* <Editor fillColor={""} width={"5px"} height={"5px"} /> */}
-				MD.Ari
+				{data.writerNickname}
 			</div>
-			<div className="basis-1/6 ">2023.11.24</div>
-			<div className="basis-1/6 ">123</div>
-			<div className="basis-1/6 ">1004</div>
+			<div className="basis-1/6 ">{data.createdAt}</div>
+			<div className="basis-1/6 ">{data.viewCount}</div>
+			<div className="basis-1/6 ">{data.likeCount}</div>
 		</div>
 	);
 };

--- a/src/pages/Forum.tsx
+++ b/src/pages/Forum.tsx
@@ -1,18 +1,49 @@
+import { Link, useNavigate } from "react-router-dom";
+import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
+
 import Pagenation from "@/components/Pagenation";
 import Button, { btnAttributes } from "@/common/button/Button";
 import HotItem from "@/components/cardItems/HotItem";
-import ForumItem from "@/components/forumItems/ForumItem";
+import ForumItem, { ForumList } from "@/components/forumItems/ForumItem";
 import Search from "@/components/search/Search";
-import { Link } from "react-router-dom";
+import FindList from "@/assets/svg/FindList";
 
 const Forum = () => {
+	const BASE_URL = import.meta.env.VITE_BASE_URL;
+	const navigate = useNavigate();
+	//새 글 등록하기 버튼 navigator 연결
+	const navigateNewForum = () => {
+		navigate("/forum/edit");
+	};
+
 	const btnInfo: btnAttributes = {
 		width: "172px",
 		// height: "50px",
 		position: "right",
 		text: "새 글 등록하기",
 		type: "square",
+		isLogin: false,
+		loginBtnType: true,
+		onClick: () => navigateNewForum,
 	};
+
+	const getForumLists = async () => {
+		try {
+			const response = await axios.get(`${BASE_URL}/api/articles `);
+			return response.data;
+		} catch (err) {
+			throw new Error(`게시판 목록 에러 ${err}`);
+		}
+	};
+
+	const { isPending, isError, data, error } = useQuery({
+		queryKey: ["forumLists"],
+		queryFn: getForumLists,
+	});
+	console.log(data);
+	if (isPending) return <span>데이터를 불러오는 중!</span>;
+	if (isError) return <span>Error: {error.message}</span>;
 
 	return (
 		<div className="flex flex-col w-full text-BASIC_BLACK">
@@ -50,11 +81,20 @@ const Forum = () => {
 						<li className="basis-1/6">조회수</li>
 						<li className="basis-1/6">좋아요</li>
 					</ul>
-					{Array.from(Array(8), (_, index) => (
-						<Link to={"/forum/detail"}>
-							<ForumItem key={index} />
-						</Link>
-					))}
+					{data.result.length !== 0 ? (
+						data.result.map((list: ForumList) => {
+							<Link to={`/forum/detail/${list.articleId}`}>
+								<ForumItem key={list.articleId} data={list} />
+							</Link>;
+						})
+					) : (
+						<div className="flex flex-col items-center justify-center h-56 bg-ITEM_BG_COLOR">
+							<FindList width={"90px"} height={"90px"} />
+							<div className="text-xl font-bold text-BASIC_BLACK">
+								I am not 데이터예요.
+							</div>
+						</div>
+					)}
 				</div>
 				<Button btnInfo={btnInfo} />
 				<Pagenation />


### PR DESCRIPTION
# 개요 
포럼 페이지에서 전체 목록 데이터 조회 기능 구현 및 버튼 컴포넌트의 로그인 여부 확인을 위한 로직 재 정립 

# 작업 사항 
- 포럼 페이지에서 전체 목록 데이터 조회 
    - 데이터 없을 경우도 대체 SVG 로 구현 
- 버튼 컴포넌트의 (로그인 여부 확인 용 ) 로직 재 정립 
    - 로그인 여부 확인용일 경우 (isLogin, loginBtnType)  속성만 정의할 경우 확인 가능. 
    - Modal 내에서 로그인 용 버튼으로 사용하겠다고 설정 할 시 내부에서 로그인용 보달 전달합니다. 

# 미리 보기 
<img width="958" alt="스크린샷 2023-12-14 오후 11 32 22" src="https://github.com/TRIP-Side-Project/frontend/assets/110151638/2d900fc8-b164-4f59-b3d1-0cf4ff667c17">

