### PR TITLE
Feat: 태그 Recoil 전역 사용 및 에디터 등록 페이지 react-hook-form 제거

### DIFF
--- a/src/common/tag/RecoilTag.tsx
+++ b/src/common/tag/RecoilTag.tsx
@@ -1,0 +1,85 @@
+import { useRecoilState, useRecoilValue } from "recoil";
+import { TagItem } from "./Tag";
+import { tagState, tagSelector, allTagState } from "@/store/tagState";
+import { useCallback } from "react";
+
+interface RecoilTagTypes {
+	isTagOpen: boolean;
+	onOffTag: () => void;
+}
+
+const RecoilTag = ({ isTagOpen, onOffTag }: RecoilTagTypes) => {
+	const [, setSelectedList] = useRecoilState(tagState);
+	const [allList] = useRecoilState(allTagState);
+	const filteredList = useRecoilValue(tagSelector);
+
+	const handleClickTag = useCallback(
+		(clickTag: string) => {
+			setSelectedList((prev) => {
+				const isTagAlreadySelected = prev.includes(clickTag);
+
+				// if (!prev) {
+				// 	return [clickTag];
+				// }
+
+				if (isTagAlreadySelected) {
+					//이미 존재한다면
+					return [...prev];
+				}
+
+				//새로운 태그라면
+				return [...prev, clickTag];
+			});
+		},
+		[setSelectedList],
+	);
+
+	const handleDeleteTag = useCallback(
+		(event: React.MouseEvent<HTMLDivElement>, tagIndex: number) => {
+			event.stopPropagation();
+			setSelectedList((prev) => {
+				const currTags = [...prev];
+				currTags.splice(tagIndex, 1);
+				return currTags;
+			});
+		},
+		[setSelectedList],
+	);
+
+	return (
+		<>
+			<div
+				className="flex text-sm font-semibold border bg-BAISC_WHITE flex-rowpx-3 rounded-xl border-BASIC_BLACK h-9"
+				onClick={onOffTag}
+			>
+				<div className="flex flex-row ">
+					{filteredList.map((el, idx) => (
+						<TagItem
+							key={idx}
+							tagData={el}
+							tagIdx={idx}
+							type={"amend"}
+							showDeleteTag={(event) => handleDeleteTag(event, idx)}
+						/>
+					))}
+				</div>
+			</div>
+
+			{isTagOpen && (
+				<div className="relative z-30 flex flex-row flex-wrap w-full p-2 text-sm font-semibold rounded-lg shadow-2xl top-1 h-fit bg-zinc-200">
+					{allList.map((tag, idx) => (
+						<TagItem
+							key={idx}
+							tagData={tag}
+							tagIdx={idx}
+							showSelectTag={handleClickTag}
+							type={"show"}
+						/>
+					))}
+				</div>
+			)}
+		</>
+	);
+};
+
+export default RecoilTag;

--- a/src/common/tag/Tag.tsx
+++ b/src/common/tag/Tag.tsx
@@ -3,102 +3,45 @@ import Close from "@/assets/svg/Close";
 type TagItemTypes = {
 	tagData: string;
 	tagIdx: number;
-	handleSelectTag?: (tag: string) => void;
-	handleDeleteTag?: (tagIdx: number) => void;
 	showSelectTag?: (tag: string) => void;
-	showDeleteTag?: (tagIdx: number) => void;
-};
-
-type TagTypes = {
-	setSelectTag: React.Dispatch<React.SetStateAction<string[]>>;
-	handleSelectTag?: (data: string) => void;
+	showDeleteTag?: (
+		event: React.MouseEvent<HTMLDivElement>,
+		tagIdx: number,
+	) => void;
+	type: "show" | "amend";
 };
 
 export const TagItem = ({
 	tagData,
 	tagIdx,
-	handleSelectTag,
-	handleDeleteTag,
 	showSelectTag,
 	showDeleteTag,
+	type,
 }: TagItemTypes) => {
 	return (
 		<div className="relative flex flex-row items-center px-2 py-1 mx-2 my-1 rounded-lg text-BASIC_WHITE hover:bg-ETC_COLOR bg-MAIN_COLOR whitespace-nowrap">
-			<button
-				className="mr-2"
+			<div
+				className="mr-2 cursor-pointer"
 				onClick={() => {
-					if (handleSelectTag && showSelectTag) {
-						handleSelectTag(tagData);
+					if (showSelectTag) {
 						showSelectTag(tagData);
 					}
 				}}
 			>
 				{tagData}
-			</button>
-			<button
-				className="p-1 rounded-lg hover:bg-LIGHT_GRAY_COLOR"
-				onClick={() => {
-					if (handleDeleteTag && showDeleteTag) {
-						handleDeleteTag(tagIdx);
-						showDeleteTag(tagIdx);
-					}
-				}}
-			>
-				<Close fillColor={"#FCFCFC"} width={"12px"} height={"12px"} />
-			</button>
+			</div>
+			{type === "amend" ? (
+				<div
+					className="p-1 rounded-lg hover:bg-LIGHT_GRAY_COLOR"
+					onClick={(event) => {
+						if (showDeleteTag) {
+							showDeleteTag(event, tagIdx);
+						}
+					}}
+				>
+					<Close fillColor={"#FCFCFC"} width={"12px"} height={"12px"} />
+				</div>
+			) : null}
 		</div>
 	);
 };
-
-const Tag = ({ setSelectTag, handleSelectTag }: TagTypes) => {
-	const tempTags = [
-		"부산",
-		"요트",
-		"경주",
-		"눈꽃여행",
-		"기차",
-		"제주도",
-		"스키",
-		"바다",
-		"강릉",
-		"선셋",
-		"목장",
-		"일몰",
-		"수상스키",
-		"설원",
-		"해돋이",
-	];
-
-	const showSelectTag = (tag: string) => {
-		setSelectTag((prevTag) => {
-			if (!prevTag) {
-				return [tag];
-			}
-			return [...prevTag, tag];
-		});
-	};
-
-	return (
-		<div className="relative z-30 flex flex-row flex-wrap p-2 text-sm font-semibold rounded-lg shadow-2xl top-1 bg-zinc-200">
-			{tempTags.map((tag: string, idx: number) => (
-				<TagItem
-					key={idx}
-					tagData={tag}
-					tagIdx={idx}
-					handleSelectTag={() => {
-						if (handleSelectTag) {
-							handleSelectTag(tag);
-						}
-					}}
-					showSelectTag={() => {
-						if (showSelectTag) {
-							showSelectTag(tag);
-						}
-					}}
-				/>
-			))}
-		</div>
-	);
-};
-
-export default Tag;

--- a/src/store/tagState.ts
+++ b/src/store/tagState.ts
@@ -1,0 +1,55 @@
+//ATOM 설정
+import { atom, selector } from "recoil";
+
+// interface TagTypes {
+// 	default: string[];
+// }
+
+const tempTags = [
+	"부산",
+	"요트",
+	"경주",
+	"눈꽃여행",
+	"기차",
+	"제주도",
+	"스키",
+	"바다",
+	"강릉",
+	"선셋",
+	"목장",
+	"일몰",
+	"수상스키",
+	"설원",
+	"해돋이",
+];
+
+export const tagState = atom<string[]>({
+	key: "tagState",
+	default: [],
+});
+
+export const allTagState = atom<string[]>({
+	key: "allTagState",
+	default: [...tempTags],
+});
+
+//선택된 태그를 기반으로 필터링 후 목록 반환
+export const tagSelector = selector({
+	key: "tagSelector",
+	get: ({ get }) => {
+		//원본 훼손하지 않는다.
+		const selectedTags = get(tagState);
+		const allTags = get(allTagState);
+
+		//선택된 태그가 없다면 빈 배열 반환
+		if (selectedTags.length === 0) {
+			return [];
+		}
+
+		//선택된 태그를 포함하는 태그들만 반환
+		// return allTags.filter(eachTag => allTags.includes(eachTag));
+		return allTags.filter((eachTag) =>
+			selectedTags.some((el) => eachTag.includes(el)),
+		);
+	},
+});


### PR DESCRIPTION
# 개요 
태그 Recoil 전역 사용 및 에디터 등록 페이지 react-hook-form 제거

# 작업 사항 
- 태그 Recoil 전역 설정으로 간편하게 페이지 렌더링 트리거 작동 없이 데이터 전송 작업 처리 완료 
- 수정/등록 게시판 페이지에 임시고 react-hook-form 제거


# 특이사항 
button 태그 클릭 시 페이지 리렌더링 트리거 버그 발생. 